### PR TITLE
add load_dotenv before OpenAI()

### DIFF
--- a/src/OpenAIClient.py
+++ b/src/OpenAIClient.py
@@ -1,5 +1,6 @@
 from openai import OpenAI
 import SystemMsg
+from dotenv import load_dotenv
 
 
 class OpenAIClient:
@@ -7,6 +8,7 @@ class OpenAIClient:
         """
         Initializes the OpenAIClient with the API key from the environment and creates the OpenAI client.
         """
+        load_dotenv()
         self.client = OpenAI()
         self.messages = []
 


### PR DESCRIPTION
If load_dotenv is not called before calling the OpenAI class, the dotfile will not be read, an exception will occur and the bot will not start.